### PR TITLE
Ensure all co-authors are displayed

### DIFF
--- a/.pear/contributors
+++ b/.pear/contributors
@@ -1,4 +1,5 @@
 Ryan Wessel
+Anderson Mesquita
 Master Chief
 Gandalf the Grey
 Tony Stark

--- a/.pear/matrix.md
+++ b/.pear/matrix.md
@@ -1,6 +1,7 @@
-|                  | Ryan Wessel | Master Chief | Gandalf the Grey | Tony Stark |
-| ---------------- | ----------- | ------------ | ---------------- | ---------- |
-| Ryan Wessel      |             |              |                  |            |
-| Master Chief     | 0           |              |                  |            |
-| Gandalf the Grey | 0           | 0            |                  |            |
-| Tony Stark       | 0           | 0            | 0                |            |
+|                   | Ryan Wessel | Anderson Mesquita | Master Chief | Gandalf the Grey | Tony Stark |
+| ----------------- | ----------- | ----------------- | ------------ | ---------------- | ---------- |
+| Ryan Wessel       |             |                   |              |                  |            |
+| Anderson Mesquita | 2           |                   |              |                  |            |
+| Master Chief      | 0           | 0                 |              |                  |            |
+| Gandalf the Grey  | 0           | 0                 | 0            |                  |            |
+| Tony Stark        | 0           | 0                 | 0            | 0                |            |

--- a/.pear/pear.sh
+++ b/.pear/pear.sh
@@ -16,13 +16,7 @@ if [ "$SHA1" ]; then
     exit 0;
 fi
 
-coauthors="Co-authors:"
-n=1
-while read line; do
-    coauthors="${coauthors} $line,"
-    n=$((n+1))
-done < $filename
-coauthors="$(echo $coauthors | sed 's/,$//g')" # Remove trailing comma
+coauthors="Co-authors: $(paste -s $filename | sed -e 's/\t/, /g' -e 's/, $//')"
 
 if [[ "$COMMIT_SOURCE" == "message" ]]; then
     # Append coauthors if user has provided a shorthand commit message

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pear-cli",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "A frictionless tool for tracking pair programming activity on teams",
   "exports": "./dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,6 @@
+export interface Commit {
+  authorName: string;
+  body: string;
+  authorDate: any;
+  hash: string;
+}

--- a/src/pear.sh
+++ b/src/pear.sh
@@ -16,13 +16,7 @@ if [ "$SHA1" ]; then
     exit 0;
 fi
 
-coauthors="Co-authors:"
-n=1
-while read line; do
-    coauthors="${coauthors} $line,"
-    n=$((n+1))
-done < $filename
-coauthors="$(echo $coauthors | sed 's/,$//g')" # Remove trailing comma
+coauthors="Co-authors: $(paste -s $filename | sed -e 's/\t/, /g' -e 's/, $//')"
 
 if [[ "$COMMIT_SOURCE" == "message" ]]; then
     # Append coauthors if user has provided a shorthand commit message


### PR DESCRIPTION
The last author was being ommited whenever the file did not have an
empty line at the end. This ensures every author is included, regardless
of trailing empty line.